### PR TITLE
Extend support to non-Unix-based command lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The goal of **xbox2local** is to make the process of saving your screenshots and
 
 ## Getting Started
 
-1. You'll need a Unix-based command line and any installation of [Python 3.x](https://www.python.org/downloads/). For users of other command lines, see Issue [#4](https://github.com/jdaymude/xbox2local/issues/4).
+1. You'll need a command line (Unix-based, Windows Command Prompt, or macOS Terminal) and any [Python](https://www.python.org/downloads/) installation version 3.5 or newer. You will also need the [tqdm](https://github.com/tqdm/tqdm#installation) and [pathvalidate](https://github.com/thombashi/pathvalidate#installation) packages.
 
 2. Have your Xbox Live (Microsoft) account email and password on hand. Both Free and Gold accounts are supported.
 
@@ -49,7 +49,7 @@ This file stores the ID of every screenshot and game clip that **xbox2local** ha
 If for whatever reason you want to start fresh and redownload all possible media, simply delete/move this file.
 
 
-## Troubleshooting and Gotchas
+## Troubleshooting
 
 **xbox2local** does its best to notify you if anything goes wrong when communicating with the X API or your Xbox Live account.
 Some common errors include:
@@ -77,6 +77,11 @@ In detail, **xbox2local** makes the following calls to X API each time it's run:
 
 Thus, if the total number of pages of results is greater than 60, this error will be raised and X API will stop serving results.
 See Issue [#3](https://github.com/jdaymude/xbox2local/issues/3) for further discussion.
+
+#### ERROR: media_dir path is invalid
+
+This means that the `media_dir` path you provided in `config.json` is not valid for your platform (Linux, Windows, or macOS). The error message from pathvalidate's [validate_filepath()](https://pathvalidate.readthedocs.io/en/latest/pages/examples/validate.html#validate-a-file-path) function that follows explains the error in more detail.
+Note: because sanitization rules differ slightly between platforms, running **xbox2local** with multiple command lines for the same media library may create different, similarly-named subfolders for the same game.
 
 #### No new screenshots or game clips to download
 

--- a/xbox2local.py
+++ b/xbox2local.py
@@ -46,7 +46,7 @@ def download_uri(uri, path, fname):
     Downloads the content at the specified URI to {path}/{fname}.
     """
     os.makedirs(path, exist_ok=True)
-    sp.run(["wget", "-q", "-o", "/dev/null", "-O", osp.join(path, fname), uri])
+    sp.run(['curl', '-s', '-o', osp.join(path, fname), uri])
 
 
 if __name__ == '__main__':

--- a/xbox2local.py
+++ b/xbox2local.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import json
 import os
 import os.path as osp
+from pathvalidate import sanitize_filepath, validate_filepath, ValidationError
 import subprocess as sp
 import sys
 from tqdm import tqdm
@@ -45,6 +46,7 @@ def download_uri(uri, path, fname):
     """
     Downloads the content at the specified URI to {path}/{fname}.
     """
+    path = sanitize_filepath(path, platform="auto")
     os.makedirs(path, exist_ok=True)
     sp.run(['curl', '-s', '-o', osp.join(path, fname), uri])
 
@@ -70,7 +72,12 @@ if __name__ == '__main__':
         config = json.load(f_in)
         xapi_key = config['xapi_key']
         xuid = str(make_xapi_call(xapi_key, '/v2/accountxuid')[0]['xuid'])
-        media_dir = config['media_dir']
+        try:
+            validate_filepath(config['media_dir'], platform="auto")
+            media_dir = config['media_dir']
+        except ValidationError as e:
+            tqdm.write("ERROR: media_dir path is invalid\n{}".format(e))
+            sys.exit()
 
     # Load download history.
     if osp.exists(history_fname):


### PR DESCRIPTION
Resolves #4 by:
- Replacing `wget` calls with `curl` calls since `curl` is supported on more platforms
- Adding a dependency on the [pathvalidate](https://github.com/thombashi/pathvalidate) package to validate and sanitize file paths on a per-platform basis