### PR TITLE
Migrate back-end API from X API to OpenXBL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The goal of **xbox2local** is to make the process of saving your screenshots and
 
 2. Have your Xbox Live (Microsoft) account email and password on hand. Both Free and Gold accounts are supported.
 
-3. Sign up for an [X API](https://xapi.us/) account, which is what **xbox2local** uses to interface with the Xbox Live service to download your media. Unless you have a huge number of game clips and screenshots, the free plan (60 requests per hour) will work fine.
+3. Navigate to [OpenXBL](https://xbl.io/), the API that **xbox2local** uses to interface with the Xbox Live service to download your media. Log in using your Xbox Live account.
 
-4. On your X API [profile page](https://xapi.us/profile), sign into Xbox Live with your Xbox Live account email and password.
+4. On your OpenXBL [profile page](https://xbl.io/profile), scroll down to the box labeled "API KEYS" and press the "Create +" button. Copy the newly created API key (a string of letters, numbers, and hyphens) before navigating away from the page&mdash;we'll need it in a couple steps.
 
 5. Clone this repository or download the latest [release](https://github.com/jdaymude/xbox2local/releases). Your directory structure will look like:
 ```
@@ -29,11 +29,11 @@ xbox2local
 6. Create a `users/<your username>` directory and within it create a `config.json` file with the following contents:
 ```
 {
-    "xapi_key": "your X API key from https://xapi.us/profile",
+    "api_key": "your OpenXBL API key from https://xbl.io/profile",
     "media_dir": "folder to put your media"
 }
 ```
-Copy your *API Key* from your X API [profile page](https://xapi.us/profile) into the `xapi_key` field and set the `media_dir` field to the local directory to download screenshots and game clips to (e.g., your OneDrive folder).
+Copy the *API Key* from your OpenXBL API [profile page](https://xbl.io/profile) into the `api_key` field and set the `media_dir` field to the local directory to download screenshots and game clips to (e.g., your OneDrive folder).
 
 7. Run **xbox2local** with `python xbox2local.py --username <your username>`.
 
@@ -42,47 +42,41 @@ Copy your *API Key* from your X API [profile page](https://xapi.us/profile) into
 
 **xbox2local** provides the following command line arguments:
 
-- `--username <USERNAME>` allows you to specify an alternative user to load your config file (containing your X API key and media directory), which is potentially useful if you have multiple accounts.
+- `--username <USERNAME>` allows you to specify an alternative user to load your config file (containing your OpenXBL API key and media directory), which is potentially useful if you have multiple accounts.
 
 - `--media_type {screenshots, gameclips, both}` allows you to specify whether to download only screenshots, only game clips, or both. The default is both.
 
 After running **xbox2local** at least once in which it succeeds in downloading your media, a `history.json` file will be created in your `users/<your username>` directory.
 This file stores the ID of every screenshot and game clip that **xbox2local** has previously downloaded so that, on subsequent runs, it does not download duplicates.
-If for whatever reason you want to start fresh and redownload all possible media, simply delete/move this file.
+If for whatever reason you want to start fresh and redownload all media stored by Xbox Live, simply delete/move this file.
 
 
 ## Troubleshooting
 
-**xbox2local** does its best to notify you if anything goes wrong when communicating with the X API or your Xbox Live account.
+**xbox2local** does its best to notify you if anything goes wrong when communicating with the OpenXBL API or your Xbox Live account.
 Some common errors include:
 
-#### ERROR 401: No API Key provided or invalid API Key
+#### ERROR 401: X-Authorization header misssing or Invalid API Key
 
-This means that either you did not provide your X API key in `config.json` or the X API key you provided is incorrect.
-
-#### ERROR 401: A fresh login is required to gain a new token from Microsoft
-
-This means that the X API key you provided in `config.json` is good, but your Xbox Live login via X API has expired.
-This is easily fixed by signing into Xbox Live again on your X API [profile page](https://xapi.us/profile).
+This means that either you did not provide your OpenXBL API key in `config.json` or the API key you provided is invalid.
 
 #### ERROR 403: API Rate Limit Exceeded
 
-This means that you have made more calls to X API than your subscription plan allows.
-The free tier allows 60 requests per hour.
+This means that you have made more calls to OpenXBL API than your subscription plan allows.
 TL;DR: this limit can be violated if you have a huge number of screenshots and game clips.
-This can potentially be circumvented by using the `--media_type` option to only download screenshots, waiting for the limit to reset in the next hour, and then using it again to only download game clips.
+As of this writing, the free tier allows 150 requests per hour and there are larger quotas available via paid subscriptions.
+This error potentially be circumvented by using the `--media_type` option to only download screenshots, waiting for the limit to reset in the next hour, and then using it again to only download game clips.
+You can track your usage in real time on your OpenXBL [profile page](https://xbl.io/profile).
 
-In detail, **xbox2local** makes the following calls to X API each time it's run:
-- One call to the `/v2/accountxuid` endpoint to verify the given X API key and obtain your Xbox Profile User ID (xuid).
-- One call to the `/v2/{xuid}/screenshots` endpoint per page of screenshot results (X API uses pagination to ensure that no single request is too big).
-- One call to the `/v2/{xuid}/game-clips` endpoint per page of game clip results.
+In detail, **xbox2local** makes the following calls to OpenXBL API each time it's run:
+- One call to the `/api/v2/screenshots` endpoint per page of screenshot results (OpenXBL uses pagination to ensure that no single request is too big).
+- One call to the `/api/v2/gameclips` endpoint per page of game clip results.
 
-Thus, if the total number of pages of results is greater than 60, this error will be raised and X API will stop serving results.
 See Issue [#3](https://github.com/jdaymude/xbox2local/issues/3) for further discussion.
 
 #### ERROR: media_dir path is invalid
 
-This means that the `media_dir` path you provided in `config.json` is not valid for your platform (Linux, Windows, or macOS). The error message from pathvalidate's [validate_filepath()](https://pathvalidate.readthedocs.io/en/latest/pages/examples/validate.html#validate-a-file-path) function that follows explains the error in more detail.
+This means that the `media_dir` path you provided in `config.json` is not valid for your platform (Linux, Windows, or macOS). The pathvalidate [validate_filepath()](https://pathvalidate.readthedocs.io/en/latest/pages/examples/validate.html#validate-a-file-path) function will print a more detailed error message.
 Note: because sanitization rules differ slightly between platforms, running **xbox2local** with multiple command lines for the same media library may create different, similarly-named subfolders for the same game.
 
 #### No new screenshots or game clips to download
@@ -90,6 +84,14 @@ Note: because sanitization rules differ slightly between platforms, running **xb
 This message is expected behavior when there really isn't anything new to download.
 However, if you receive this message unexpectedly, check your *Settings > Preferences > Capture & Share > Automatically upload* settings on your Xbox.
 This should be set to something other than *Don't upload*; otherwise, all screenshots and game clips you capture stay on your Xbox's local storage and are not uploaded to Xbox Live, so **xbox2local** cannot access them.
+
+
+## Upgrading from Prior Versions
+
+Updating an older version of **xbox2local** to a [new release](https://github.com/jdaymude/xbox2local/releases) requires a basic understanding of [semantic versioning](https://semver.org/), where version numbers are written as `MAJOR.MINOR.PATCH`.
+If your older version and the updated version have the same `MAJOR` number, you can replace your `xbox2local.py` file with the [newest version](https://github.com/jdaymude/xbox2local/blob/master/xbox2local.py) and things should just work.
+If you are updating to a new `MAJOR` version (e.g., from `v1.#.#` to `v2.#.#`), there may be additional changes you need to make manually.
+The release notes for the corresponding major update (e.g., `v2.0.0`) will have instructions for those changes, if applicable.
 
 
 ## Contributing


### PR DESCRIPTION
Moving from [X API](https://xapi.us/) to [OpenXBL](https://xbl.io/) (v3.0.1 as of this writing) fixes several bugs and other API-related issues:
- Resolves #9 since OpenXBL seems to find all "invisible" games in testing.
- Resolves #13 since OpenXBL authenticates directly with Microsoft's login system, regardless of 2FA status.
- Resolves #14 which was caused by X API's paywalled restructuring.
- Allows for the possibility of addressing #2 since OpenXBL has a `/api/v2/dvr/gameclips/delete/{gameClipId}` endpoint for deleting gameclips (the more storage intensive of the two types of media).