### PR TITLE
Reflect media capture datetime in OS file metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This should be set to something other than *Don't upload*; otherwise, all screen
 
 Updating an older version of **xbox2local** to a [new release](https://github.com/jdaymude/xbox2local/releases) requires a basic understanding of [semantic versioning](https://semver.org/), where version numbers are written as `MAJOR.MINOR.PATCH`.
 If your older version and the updated version have the same `MAJOR` number, you can replace your `xbox2local.py` file with the [newest version](https://github.com/jdaymude/xbox2local/blob/master/xbox2local.py) and things should just work.
+Any backwards compatibility issues can be addressed by running the corresponding functions in [`update.py`](https://github.com/jdaymude/xbox2local/blob/master/update.py).
 If you are updating to a new `MAJOR` version (e.g., from `v1.#.#` to `v2.#.#`), there may be additional changes you need to make manually.
 The release notes for the corresponding major update (e.g., `v2.0.0`) will have instructions for those changes, if applicable.
 

--- a/update.py
+++ b/update.py
@@ -1,0 +1,53 @@
+"""
+update: Helper scripts for backwards compatible updates.
+"""
+
+from xbox2local import *
+
+
+def set_accmod_datetime(username):
+    """
+    Updates all last access/modification times for downloaded media to those
+    media's capture datetime. All media downloaded with xbox2local v2.1 or later
+    will reflect this behavior automatically.
+
+    :param username: a string username whose media should be updated
+    """
+    # Load API key and media directory.
+    with open(osp.join('users', username, 'config.json')) as f_in:
+        config = json.load(f_in)
+        try:
+            validate_filepath(config['media_dir'], platform="auto")
+            media_dir = config['media_dir']
+        except ValidationError as err:
+            tqdm.write(f"ERROR: media_dir path is invalid\n{err}")
+            sys.exit()
+
+    # Load history of previously downloaded media.
+    history_fpath = osp.join('users', username, 'history.csv')
+    if osp.exists(history_fpath):
+        history_df = pd.read_csv(history_fpath, index_col='id')
+    else:
+        tqdm.write(f"No downloaded media to update")
+        sys.exit()
+
+    # Set all media's last accessed and modified times to their capture times.
+    tqdm.write('Updating downloaded media\'s last access/modify times...')
+    for media in tqdm(list(history_df.itertuples())):
+        fpath = osp.join(media_dir, media.game, media.capture_dt)
+        ext = '.png' if media.type == 'screenshot' else '.mp4'
+        accmod_dt = datetime.strptime(media.capture_dt, DT_FMT)
+        os.utime(fpath + ext, (accmod_dt.timestamp(), accmod_dt.timestamp()))
+
+
+if __name__ == '__main__':
+    # Parse command line arguments.
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-U', '--username', required=True,
+                        help='The users/ subdirectory with your data')
+    parser.add_argument('-F', '--function', choices=['set_accmod_datetime'],
+                        help='The update function to run')
+    args = parser.parse_args()
+
+    if args.function == 'set_accmod_datetime':
+        set_accmod_datetime(args.username)

--- a/xbox2local.py
+++ b/xbox2local.py
@@ -28,6 +28,7 @@ def make_api_call(api_key, endpoint):
     request is successful, its output is returned as a dict and any
     continuation token in its header is returned as a string. If unsuccessful,
     the error code and message are displayed and the script exits.
+
     :param api_key: a string API key from https://xbl.io/profile
     :param endpoint: a string API endpoint from https://xbl.io/console
     :returns: a string HTTP reponse from the API call
@@ -61,6 +62,7 @@ def make_api_call(api_key, endpoint):
 def fmt_datetime(datestr):
     """
     Reformats a date/time string so that it avoids any special characters.
+
     :param datestr: a string representing a date/time in 'YYYY-mm-dd HH:MM:SSZ',
                     'YYYY-mm-ddTHH:MM:SSZ', or 'YYYY-mm-ddTHH:MM:SS.fffZ' format
     :returns: a string representing a date/time in 'YYYY-mm-ddTHH-MM-SS' format
@@ -75,6 +77,13 @@ def fmt_datetime(datestr):
 
 
 def fmt_sizeof(num, suffix="B"):
+    """
+    Formats a number in a human-readable order of magnitude using base-1024.
+
+    :param num: an int or float number
+    :param suffix: an optional string suffix; by default "B" for bytes
+    :returns: a formatted string representation of the input number
+    """
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
         if abs(num) < 1024.0:
             return f"{num:3.1f}{unit}{suffix}"
@@ -87,6 +96,7 @@ def download_uri(uri, fpath, accmod_dt):
     """
     Downloads the content at the specified URI to {path}/{fname} and then set
     the last accessed and modified times to the specified datetime.
+
     :param uri: a string URI for the media to download
     :param fpath: a string file path to download the media to
     :param accmod_dt: a datetime object for the file's last access/modify time


### PR DESCRIPTION
- Resolves #22 by writing media capture times (as reported by the Xbox network) as the downloaded files' last access/modification times, enabling better compatibility with photo/video viewing and organization software. Implementation details are discussed in #23.
- Adds an `update.py` script for applying new features, like this access/modification time update, to the previously downloaded media in a non-destructive way.
- Updated sorting of the `history.csv` file to reverse chronological order by capture datetime to enable easier identification of newly downloaded media.