### PR TITLE
Make all datetimes time zone aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # xbox2local
 
 Welcome to **xbox2local**, a command line utility written in Python for downloading all your Xbox [screenshots and game clips](https://support.xbox.com/help/friends-social-activity/share-socialize/capture-game-clips-and-screenshots) to your computer.
-As of this writing, Microsoft only allows automatic uploads of screenshots and game clips to the Xbox network, where [subtle rules](https://support.xbox.com/help/games-apps/my-games-apps/manage-clips-with-upload-studio) dictate how long your content sticks around.
 
 The goal of **xbox2local** is to make the process of saving your screenshots and game clips much faster.
 Each time you run it, it (1) detects all your media on the Xbox network that it hasn't saved before, (2) copies them to a local folder of your choosing, and (3) gives you the option of deleting them from the Xbox network to free up storage.
+I wrote this tool as an alternative to Team Xbox's [ever](https://support.xbox.com/help/games-apps/my-games-apps/manage-clips-with-upload-studio) [changing](https://news.xbox.com/en-us/2022/11/16/xbox-november-2022-update-rolls-out-today/) [capture policies](https://news.xbox.com/en-us/2023/09/27/bonus-xbox-update-for-september/) [and procedures](https://support.xbox.com/en-US/help/games-apps/my-games-apps/back-up-game-clips) so you can keep better control of your content.
 
 
-## A Note on the Xbox November 2022 Update
+## A Note on the Xbox September 2023 Update
 
-As of the [Xbox November 2022 Update](https://news.xbox.com/en-us/2022/11/16/xbox-november-2022-update-rolls-out-today/), Team Xbox has finally provided official support for bulk media backups to OneDrive or external storage in addition to the older clip-by-clip [sharing options](https://support.xbox.com/help/games-apps/my-games-apps/share-clips-xbox-one).
+As of the [Xbox September 2023 Update](https://news.xbox.com/en-us/2023/09/27/bonus-xbox-update-for-september/), clips and screenshots are stored on the Xbox network for 90 days and otherwise you can [back them up to OneDrive or external storage](https://support.xbox.com/en-US/help/games-apps/my-games-apps/back-up-game-clips).
 On your Xbox, navigate to *Captures > Manage > Select all > Upload to OneDrive* or *Copy to external storage*.
 For many casual users, this functionality can (and should!) replace the functionality of the **xbox2local** script.
 For power users, **xbox2local** still offers the following benefits over the native Xbox functionality:
@@ -33,7 +33,7 @@ You will also need the [pandas](https://pandas.pydata.org/), [tqdm](https://gith
 Both Free and Gold accounts are supported.
 
 3. Navigate to [OpenXBL](https://xbl.io/), the API that **xbox2local** uses to interface with the Xbox network to download your media.
-Log in using your Microsoft account.
+Log in using your Microsoft account and verify your OpenXBL account via SMS.
 
 4. On your OpenXBL [profile page](https://xbl.io/profile), scroll down to the box labeled "API KEYS" and press the "Create +" button.
 Copy the newly created API key (a string of letters, numbers, and hyphens) before navigating away from the page.

--- a/update.py
+++ b/update.py
@@ -7,9 +7,11 @@ from xbox2local import *
 
 def set_accmod_datetime(username):
     """
+    IMPORTANT: Only run this function if updating from v2.0.0!
+
     Updates all last access/modification times for downloaded media to those
-    media's capture datetime. All media downloaded with xbox2local v2.1 or later
-    will reflect this behavior automatically.
+    media's capture datetime. All media downloaded with xbox2local v2.1.0 or
+    later will do this automatically.
 
     :param username: a string username whose media should be updated
     """
@@ -36,8 +38,75 @@ def set_accmod_datetime(username):
     for media in tqdm(list(history_df.itertuples())):
         fpath = osp.join(media_dir, media.game, media.capture_dt)
         ext = '.png' if media.type == 'screenshot' else '.mp4'
-        accmod_dt = datetime.strptime(media.capture_dt, DT_FMT)
+        accmod_dt = datetime.strptime(media.capture_dt, '%Y-%m-%dT%H-%M-%S')
         os.utime(fpath + ext, (accmod_dt.timestamp(), accmod_dt.timestamp()))
+
+
+def set_timezone_awareness(username):
+    """
+    IMPORTANT: Only run this function if (1) you are updating from v2.1.0 or (2)
+    if you are updating from v2.0.0 and have already run set_accmod_datetime!
+
+    Updates all filenames and last access/modify times for downloaded media to
+    those media's capture datetime, correctly converting from UTC to local time.
+    Then updates history.json so all 'capture_dt' date/time strings are in UTC
+    and all 'download_dt' date/time strings are in local time. All media
+    downloaded with xbox2local v2.1.1 or later will do this automatically.
+
+    :param username: a string username whose media should be updated
+    """
+    # Load API key and media directory.
+    with open(osp.join('users', username, 'config.json')) as f_in:
+        config = json.load(f_in)
+        try:
+            validate_filepath(config['media_dir'], platform="auto")
+            media_dir = config['media_dir']
+        except ValidationError as err:
+            tqdm.write(f"ERROR: media_dir path is invalid\n{err}")
+            sys.exit()
+
+    # Load history of previously downloaded media.
+    history_fpath = osp.join('users', username, 'history.csv')
+    if osp.exists(history_fpath):
+        history_df = pd.read_csv(history_fpath, index_col='id')
+    else:
+        tqdm.write(f"No downloaded media to update")
+        sys.exit()
+
+    # Correct time zones in all media's filenames and last access/modify times.
+    tqdm.write('Updating downloaded media\'s last access/modify time zones...')
+    for media in tqdm(list(history_df.itertuples())):
+        # Locate the file.
+        fpath = osp.join(media_dir, media.game, media.capture_dt)
+        ext = '.png' if media.type == 'screenshot' else '.mp4'
+
+        # Rename the file.
+        cap_dt = datetime.strptime(media.capture_dt, '%Y-%m-%dT%H-%M-%S')
+        cap_dt = cap_dt.replace(tzinfo=timezone.utc)
+        new_fpath = osp.join(media_dir, media.game, cap_dt.strftime(DT_FMT))
+        os.rename(fpath + ext, new_fpath + ext)
+
+        # Correct the time zones in the last access/modify times.
+        accmod_ts = cap_dt.astimezone().timestamp()
+        os.utime(new_fpath + ext, (accmod_ts, accmod_ts))
+
+        # Do the same for the HDR version, if it exists.
+        if media.hdr_filesize > 0:
+            os.rename(fpath + '_hdr.jxr', new_fpath + '_hdr.jxr')
+            os.utime(new_fpath + '_hdr.jxr', (accmod_ts, accmod_ts))
+
+    # Set all capture date/time metadata to UTC.
+    tqdm.write('Updating time zones in history.json capture/download times...')
+    fmt_utc = lambda x: datetime.strptime(x, '%Y-%m-%dT%H-%M-%S').replace(tzinfo=timezone.utc).strftime(DT_FMT)
+    history_df.capture_dt = history_df.capture_dt.apply(fmt_utc)
+
+    # Set all download date/time metadata to local time zone.
+    fmt_loc = lambda x: datetime.strptime(x, '%Y-%m-%dT%H-%M-%S').astimezone().strftime(DT_FMT)
+    history_df.download_dt = history_df.download_dt.apply(fmt_loc)
+
+    # Save updated download history.
+    tqdm.write('Writing updated history.json...')
+    history_df.sort_values(by='capture_dt', ascending=False).to_csv(history_fpath)
 
 
 if __name__ == '__main__':
@@ -45,9 +114,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-U', '--username', required=True,
                         help='The users/ subdirectory with your data')
-    parser.add_argument('-F', '--function', choices=['set_accmod_datetime'],
-                        help='The update function to run')
+    parser.add_argument('-V', '--version', required=True,
+                        help='The version you are updating from')
     args = parser.parse_args()
 
-    if args.function == 'set_accmod_datetime':
+    if args.version == '2.0.0':
         set_accmod_datetime(args.username)
+        set_timezone_awareness(args.username)
+    elif args.version == '2.1.0':
+        set_timezone_awareness(args.username)
+    else:
+        tqdm.write(f"ERROR: No updates required from version {args.version}")


### PR DESCRIPTION
- Resolves #25 by explicitly marking all Xbox network datetimes as UTC and all local download/access/modify datetimes in the machine's local time zone.
- Reworks the `update.py` script to take as input the version number a user is updating from instead of requiring them to know the specific functions to run